### PR TITLE
Snackbar/luna

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@material-ui/core": "^4.12.3",
     "@material-ui/data-grid": "^4.0.0-alpha.37",
     "@material-ui/lab": "^4.0.0-alpha.60",
+    "@mui/material": "^5.0.2",
     "@reduxjs/toolkit": "^1.6.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,9 @@ import { FlipCard } from "./components/Flashcards/FlipCard";
 import {ConfirmSignup} from "./components/Login/ConfirmSignup";
 import {Amplify} from "aws-amplify";
 import {COGNITO} from "./config/aws";
+import { Alert, Snackbar } from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+import { errorState, hideErrorMessage } from "./state-slices/error/errorSlice";
 
 Amplify.configure({
     aws_cognito_region: COGNITO.REGION,
@@ -24,6 +27,8 @@ Amplify.configure({
 })
 
 function App() {
+  const error = useSelector(errorState);
+  const dispatch = useDispatch();
 
   // @ts-ignore
   return (
@@ -60,6 +65,11 @@ function App() {
           </Route>
         </Switch>
       </Container>
+      <Snackbar open={error.showError} autoHideDuration={3000} onClose={() => {dispatch(hideErrorMessage())}}>
+        <Alert onClose={() => {dispatch(hideErrorMessage())}} severity={error.errorSeverity} sx={{ width: '100%' }}>
+          {error.errorMsg}
+        </Alert>
+      </Snackbar>
       <footer>
         <Row className="bg-dark text-light">
           <Col>

--- a/src/state-slices/error/errorSlice.ts
+++ b/src/state-slices/error/errorSlice.ts
@@ -1,14 +1,22 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { RootState } from "../../store/store";
+import { AlertColor } from '@mui/material';
 
 interface State {
     errorMsg: string;
     showError: boolean;
+    errorSeverity: AlertColor;
 }
 
 const initialState: State = {
     errorMsg: "",
     showError: false,
+    errorSeverity: 'info'
+}
+
+class errorInput {
+    message: string;
+    severity: AlertColor;
 }
 
 export const errorSlice = createSlice({
@@ -16,12 +24,18 @@ export const errorSlice = createSlice({
     initialState,
     reducers: {
         showErrorMessage: (state, action: PayloadAction<string>) => {
-            state.errorMsg = action.payload;
+            state.errorMsg = action.payload; 
+            state.showError = true;
+        },
+        showSnackbar: (state, action: PayloadAction<errorInput>) => {
+            state.errorMsg = action.payload.message;
+            state.errorSeverity = action.payload.severity;
             state.showError = true;
         },
         hideErrorMessage: (state) => {
             state.errorMsg = "";
             state.showError = false;
+            state.errorSeverity = 'info';
         }
     }
 });

--- a/src/state-slices/error/errorSlice.ts
+++ b/src/state-slices/error/errorSlice.ts
@@ -40,7 +40,7 @@ export const errorSlice = createSlice({
     }
 });
 
-export const { showErrorMessage, hideErrorMessage } = errorSlice.actions;
+export const { showErrorMessage, showSnackbar, hideErrorMessage } = errorSlice.actions;
 
 export const errorState = (state: RootState) => state.error;
 

--- a/src/state-slices/error/errorSlice.ts
+++ b/src/state-slices/error/errorSlice.ts
@@ -19,10 +19,15 @@ class errorInput {
     severity: AlertColor;
 }
 
+/**
+ * Slice of state for errors. note: DO NOT USE showErrorMessage, it will be deprecated within the week
+ * @author 'Luna Haines'
+ */
 export const errorSlice = createSlice({
     name: "error",
     initialState,
     reducers: {
+        // BEING DEPRECATED SOON! DO NOT USE!
         showErrorMessage: (state, action: PayloadAction<string>) => {
             state.errorMsg = action.payload; 
             state.showError = true;


### PR DESCRIPTION
updates to error slice (state with redux) to use a snackbar. This now includes an option to change severity (default: info).  In order to set an error message, there is a reducer called showSnackbar which can be leveraged, it's required input is a message (string) and a severity ('info', 'success', 'warning', or 'error'). showErrorMessage still exists for compatibility reasons and should be removed in the future.