### PR TITLE
no more obnoxiously huge buttons

### DIFF
--- a/src/components/Multiplayer/Game.tsx
+++ b/src/components/Multiplayer/Game.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles({
     },
 
     playerContainer: {
-        display: 'flex',
+        display: 'block',
         marginRight: '1rem',
     },
 
@@ -77,6 +77,7 @@ const useStyles = makeStyles({
 
     buttons: {
         backgroundColor: 'rgb(245,245,245)',
+        width: '21rem',
         margin: '1rem',
         marginLeft: '0rem'
     },

--- a/src/components/Multiplayer/Players.tsx
+++ b/src/components/Multiplayer/Players.tsx
@@ -45,6 +45,9 @@ import { guestState } from '../../state-slices/multiplayer/guest-slice';
       },
       closeGameButton: {
         backgroundColor: 'rgb(245,245,245)',
+        width: '21rem',
+        marginTop: '1rem',
+        marginLeft: '0rem'
       }
   }))
   


### PR DESCRIPTION
When playing a game, the "Next Card" and "See Leaderboard" buttons will no longer be the same height as the Question and Answers